### PR TITLE
Fix answer to 11008

### DIFF
--- a/standards/JavaScript/1.1-function-scopes.xml
+++ b/standards/JavaScript/1.1-function-scopes.xml
@@ -228,8 +228,8 @@
     </body>
     <choice-group>
       <choice>10</choice>
-      <choice>20</choice>
-      <choice answer>30</choice>
+      <choice answer>20</choice>
+      <choice>30</choice>
     </choice-group>
   </question>
 </group>


### PR DESCRIPTION
`bar()` is a no-op as it does not assign to the same `x` that `foo` returns.

This stuff is really fiddly, I would very highly recommend writing a tool that can evaluate these expressions and verify that the answers are actually correct. In the past I've done this kind of instrumentation using a transform with esprima + escodegen (although those aren't the only tools for transforming js these days).