### PR TITLE
Remove typo from 23007

### DIFF
--- a/standards/JavaScript/2.3-keword-_this-binding.xml
+++ b/standards/JavaScript/2.3-keword-_this-binding.xml
@@ -190,7 +190,7 @@
 
       var result = greet.call(XXX);
 
-      assert.equal(result, "Alice says hello to Bob");3
+      assert.equal(result, "Alice says hello to Bob");
     </given-code>
   </question>
 </group>


### PR DESCRIPTION
The trailing `3` isn't a syntax error but could be confusing.